### PR TITLE
Feature/glutin 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 imgui = "0.4"
-grr = { path = "/home/mason/workspace/grr" }
+grr = "0.7"
 
 [dev-dependencies]
 glutin = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["msiglreith <m.siglreith@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-imgui = "0.2"
-grr = "0.7"
+imgui = "0.4"
+grr = { path = "/home/mason/workspace/grr" }
 
 [dev-dependencies]
-glutin = "0.19"
-imgui-winit-support = "0.2"
+glutin = "0.24"
+imgui-winit-support = "0.4"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,37 +1,35 @@
-#[macro_use]
-extern crate imgui;
-
-use glutin::dpi::LogicalSize;
-use glutin::GlContext;
+use glutin::dpi::{LogicalSize, PhysicalSize};
+use glutin::platform::desktop::EventLoopExtDesktop;
 
 use std::time::Instant;
 
 fn main() -> grr::Result<()> {
-    unsafe {
-        let mut events_loop = glutin::EventsLoop::new();
-        let window = glutin::WindowBuilder::new()
-            .with_title("Hello, world!")
-            .with_dimensions(LogicalSize {
-                width: 1024.0,
-                height: 768.0,
-            });
-        let context = glutin::ContextBuilder::new()
+    let mut event_loop = glutin::event_loop::EventLoop::new();
+    let wb = glutin::window::WindowBuilder::new()
+        .with_title("Hello, world!")
+        .with_inner_size(LogicalSize {
+            width: 1024.0,
+            height: 768.0,
+        });
+
+    let window = unsafe {
+        glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_srgb(true)
-            .with_gl_debug_flag(true);
+            .with_gl_debug_flag(true)
+            .build_windowed(wb, &event_loop)
+            .unwrap()
+            .make_current()
+            .unwrap()
+    };
 
-        let window = glutin::GlWindow::new(window, context, &events_loop).unwrap();
+    let PhysicalSize {
+        width: mut w,
+        height: mut h,
+    } = window.window().inner_size();
 
-        let LogicalSize {
-            width: w,
-            height: h,
-        } = window.get_inner_size().unwrap();
-
-        unsafe {
-            window.make_current().unwrap();
-        }
-
-        let grr = grr::Device::new(
+    let grr = unsafe {
+        grr::Device::new(
             |symbol| window.get_proc_address(symbol) as *const _,
             grr::Debug::Enable {
                 callback: |_, _, _, _, msg| {
@@ -39,59 +37,71 @@ fn main() -> grr::Result<()> {
                 },
                 flags: grr::DebugReport::FULL,
             },
-        );
+        )
+    };
 
-        let mut imgui = imgui::Context::create();
-        imgui.set_ini_filename(None);
+    let mut imgui = imgui::Context::create();
+    imgui.set_ini_filename(None);
 
-        let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
+    let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
 
-        let hidpi_factor = window.get_hidpi_factor();
-        let font_size = (13.0 * hidpi_factor) as f32;
+    let hidpi_factor = window.window().scale_factor();
+    let font_size = (13.0 * hidpi_factor) as f32;
 
-        imgui
-            .fonts()
-            .add_font(&[imgui::FontSource::DefaultFontData {
-                config: Some(imgui::FontConfig {
-                    size_pixels: font_size,
-                    ..imgui::FontConfig::default()
-                }),
-            }]);
+    imgui
+        .fonts()
+        .add_font(&[imgui::FontSource::DefaultFontData {
+            config: Some(imgui::FontConfig {
+                size_pixels: font_size,
+                ..imgui::FontConfig::default()
+            }),
+        }]);
 
-        imgui.io_mut().font_global_scale = ((1.0 / hidpi_factor) as f32);
+    imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
 
-        let imgui_renderer = grr_imgui::Renderer::new(&mut imgui, &grr)?;
-        platform.attach_window(
-            imgui.io_mut(),
-            window.window(),
-            imgui_winit_support::HiDpiMode::Rounded,
-        );
+    let imgui_renderer = unsafe { grr_imgui::Renderer::new(&mut imgui, &grr)? };
 
-        let mut running = true;
-        let mut last_frame = Instant::now();
+    platform.attach_window(
+        imgui.io_mut(),
+        window.window(),
+        imgui_winit_support::HiDpiMode::Rounded,
+    );
 
-        while running {
-            events_loop.poll_events(|event| {
-                platform.handle_event(imgui.io_mut(), window.window(), &event);
-                match event {
-                    glutin::Event::WindowEvent { event, .. } => match event {
-                        glutin::WindowEvent::CloseRequested => running = false,
-                        glutin::WindowEvent::Resized(size) => {
-                            let dpi_factor = window.get_hidpi_factor();
-                            window.resize(size.to_physical(dpi_factor));
-                        }
-                        _ => (),
-                    },
-                    _ => (),
+    let mut running = true;
+    let mut last_frame = Instant::now();
+
+    event_loop.run_return(|event, _, control_flow| {
+        unsafe {
+            platform.handle_event(imgui.io_mut(), window.window(), &event);
+            *control_flow = glutin::event_loop::ControlFlow::Poll;
+            match event {
+                glutin::event::Event::MainEventsCleared => {}
+                glutin::event::Event::WindowEvent { event, .. } => match event {
+                    glutin::event::WindowEvent::CloseRequested => {
+                        *control_flow = glutin::event_loop::ControlFlow::Exit;
+                        return;
+                    }
+                    glutin::event::WindowEvent::Resized(size) => {
+                        w = size.width;
+                        h = size.height;
+                        //window.resize(size);
+                        return;
+                    }
+                    _ => {
+                        return;
+                    }
+                },
+                _ => {
+                    return;
                 }
-            });
+            }
 
             let io = imgui.io_mut();
             platform
                 .prepare_frame(io, window.window())
                 .expect("Failed to start frame");
             last_frame = io.update_delta_time(last_frame);
-            let mut ui = imgui.frame();
+            let ui = imgui.frame();
             ui.show_demo_window(&mut running);
 
             grr.set_viewport(
@@ -120,10 +130,10 @@ fn main() -> grr::Result<()> {
                 grr::ClearAttachment::ColorFloat(0, [0.5, 0.5, 0.5, 1.0]),
             );
 
-            imgui_renderer.render(ui.render());
+            imgui_renderer.render(ui.render()).unwrap();
             window.swap_buffers().unwrap();
         }
-    }
+    });
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,16 +58,27 @@ impl<'grr> Renderer<'grr> {
             }
         }
 
-        let vs = grr.create_shader(grr::ShaderStage::Vertex, VERTEX_SRC.as_bytes())?;
-        let fs = grr.create_shader(grr::ShaderStage::Fragment, FRAGMENT_SRC.as_bytes())?;
+        let vs = grr.create_shader(
+            grr::ShaderStage::Vertex,
+            VERTEX_SRC.as_bytes(),
+            grr::ShaderFlags::VERBOSE,
+        )?;
+        let fs = grr.create_shader(
+            grr::ShaderStage::Fragment,
+            FRAGMENT_SRC.as_bytes(),
+            grr::ShaderFlags::VERBOSE,
+        )?;
 
-        let pipeline = grr.create_graphics_pipeline(grr::VertexPipelineDesc {
-            vertex_shader: vs,
-            tessellation_control_shader: None,
-            tessellation_evaluation_shader: None,
-            geometry_shader: None,
-            fragment_shader: Some(fs),
-        })?;
+        let pipeline = grr.create_graphics_pipeline(
+            grr::VertexPipelineDesc {
+                vertex_shader: vs,
+                tessellation_control_shader: None,
+                tessellation_evaluation_shader: None,
+                geometry_shader: None,
+                fragment_shader: Some(fs),
+            },
+            grr::PipelineFlags::VERBOSE,
+        )?;
 
         let mut textures = imgui::Textures::new();
         let mut fonts = imgui.fonts();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,27 +58,16 @@ impl<'grr> Renderer<'grr> {
             }
         }
 
-        let vs = grr.create_shader(
-            grr::ShaderStage::Vertex,
-            VERTEX_SRC.as_bytes(),
-            grr::ShaderFlags::VERBOSE,
-        )?;
-        let fs = grr.create_shader(
-            grr::ShaderStage::Fragment,
-            FRAGMENT_SRC.as_bytes(),
-            grr::ShaderFlags::VERBOSE,
-        )?;
+        let vs = grr.create_shader(grr::ShaderStage::Vertex, VERTEX_SRC.as_bytes())?;
+        let fs = grr.create_shader(grr::ShaderStage::Fragment, FRAGMENT_SRC.as_bytes())?;
 
-        let pipeline = grr.create_graphics_pipeline(
-            grr::VertexPipelineDesc {
-                vertex_shader: vs,
-                tessellation_control_shader: None,
-                tessellation_evaluation_shader: None,
-                geometry_shader: None,
-                fragment_shader: Some(fs),
-            },
-            grr::PipelineFlags::VERBOSE,
-        )?;
+        let pipeline = grr.create_graphics_pipeline(grr::VertexPipelineDesc {
+            vertex_shader: vs,
+            tessellation_control_shader: None,
+            tessellation_evaluation_shader: None,
+            geometry_shader: None,
+            fragment_shader: Some(fs),
+        })?;
 
         let mut textures = imgui::Textures::new();
         let mut fonts = imgui.fonts();


### PR DESCRIPTION
This updates the dependencies and allows the example to run on recent versions of glutin and winit. 

This version still runs on `grr` 0.7, so the shader and pipeline creation calls do not include the new flags.