### PR TITLE
update to grr 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grr-imgui"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["msiglreith <m.siglreith@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 imgui = "0.4"
-grr = "0.7"
+grr = "0.8"
 
 [dev-dependencies]
 glutin = "0.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,16 +64,27 @@ impl<'grr> Renderer<'grr> {
             }
         }
 
-        let vs = grr.create_shader(grr::ShaderStage::Vertex, VERTEX_SRC.as_bytes())?;
-        let fs = grr.create_shader(grr::ShaderStage::Fragment, FRAGMENT_SRC.as_bytes())?;
+        let vs = grr.create_shader(
+            grr::ShaderStage::Vertex,
+            VERTEX_SRC.as_bytes(),
+            grr::ShaderFlags::empty(),
+        )?;
+        let fs = grr.create_shader(
+            grr::ShaderStage::Fragment,
+            FRAGMENT_SRC.as_bytes(),
+            grr::ShaderFlags::empty(),
+        )?;
 
-        let pipeline = grr.create_graphics_pipeline(grr::VertexPipelineDesc {
-            vertex_shader: vs,
-            tessellation_control_shader: None,
-            tessellation_evaluation_shader: None,
-            geometry_shader: None,
-            fragment_shader: Some(fs),
-        })?;
+        let pipeline = grr.create_graphics_pipeline(
+            grr::VertexPipelineDesc {
+                vertex_shader: vs,
+                tessellation_control_shader: None,
+                tessellation_evaluation_shader: None,
+                geometry_shader: None,
+                fragment_shader: Some(fs),
+            },
+            grr::PipelineFlags::empty(),
+        )?;
 
         let mut textures = imgui::Textures::new();
         let mut fonts = imgui.fonts();
@@ -93,24 +104,26 @@ impl<'grr> Renderer<'grr> {
                 .unwrap();
             grr.object_name(image, "imgui-texture");
             grr.copy_host_to_image(
-                image,
-                grr::SubresourceLevel {
-                    level: 0,
-                    layers: 0..1,
-                },
-                grr::Offset { x: 0, y: 0, z: 0 },
-                grr::Extent {
-                    width: texture.width,
-                    height: texture.height,
-                    depth: 1,
-                },
                 &texture.data,
-                grr::SubresourceLayout {
-                    base_format: grr::BaseFormat::RGBA,
-                    format_layout: grr::FormatLayout::U8,
-                    row_pitch: texture.width,
-                    image_height: texture.height,
-                    alignment: 4,
+                image,
+                grr::HostImageCopy {
+                    host_layout: grr::MemoryLayout {
+                        base_format: grr::BaseFormat::RGBA,
+                        format_layout: grr::FormatLayout::U8,
+                        row_length: texture.width,
+                        image_height: texture.height,
+                        alignment: 4,
+                    },
+                    image_subresource: grr::SubresourceLayers {
+                        level: 0,
+                        layers: 0..1,
+                    },
+                    image_offset: grr::Offset { x: 0, y: 0, z: 0 },
+                    image_extent: grr::Extent {
+                        width: texture.width,
+                        height: texture.height,
+                        depth: 1,
+                    },
                 },
             );
 


### PR DESCRIPTION
Update the grr calls within grr-imgui to reflect the new grr 0.8 API. 

Also bumps the version number to 0.2 since the dependencies change. This could be a revision change instead (to 0.1.1).